### PR TITLE
Adding back the miniwindow resize tag

### DIFF
--- a/Search_and_Destroy_v2.0.xml
+++ b/Search_and_Destroy_v2.0.xml
@@ -2472,6 +2472,7 @@
 		end
 		draw_circle_readout()		-- add circle text/level readout
 		draw_noexp_cutoff(213, 22)	-- add noexp cutoff indicator
+		draw_resize_tag()
 		Redraw()
 	end
 


### PR DESCRIPTION
Added draw_resize_tag() in last line of xg_draw_window() function. Line 2475.